### PR TITLE
Bump coral to 2.2.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>io.trino.coral</groupId>
     <artifactId>coral</artifactId>
-    <version>2.0.153-2-SNAPSHOT</version>
+    <version>2.2.14-1-SNAPSHOT</version>
 
     <description>Shaded version of Coral for Trino</description>
     <url>https://github.com/trinodb/trino-coral</url>
@@ -41,7 +41,7 @@
         <project.build.targetJdk>17</project.build.targetJdk>
         <shadeCalcite>com.linkedin.coral.calcite.\$internal</shadeCalcite>
         <shadeCoral>com.linkedin.coral.\$internal</shadeCoral>
-        <dep.coral.version>2.0.153</dep.coral.version>
+        <dep.coral.version>2.2.14</dep.coral.version>
         <dep.hive.version>3.1.3</dep.hive.version>
     </properties>
 


### PR DESCRIPTION
Overview of the past releases is available at
https://github.com/linkedin/coral/releases


Relevant releases:
- https://github.com/linkedin/coral/releases/tag/v2.2.14
[Coral-Trino] Avoid accidental translation of Trino from_unixtime SQL call - SqlFunction implementation https://github.com/linkedin/coral/pull/467
- https://github.com/linkedin/coral/releases/tag/v2.1.0 
[Coral-Trino] [Backward Incompatible] Refactor RelToTrinoConverter API https://github.com/linkedin/coral/pull/420
- https://github.com/linkedin/coral/releases/tag/v2.2.9
[Coral-Trino] Cast char fields, if necessary, to varchar type in the set operation - SqlCallTransformer https://github.com/linkedin/coral/pull/442
Due to wrong coercion between varchar and char in Trino, as described in https://github.com/trinodb/trino/issues/9031
, a work-around needs to be applied in case of translating Hive views which contain a UNION dealing with char and varchar types. The work-around consists in the explicit cast of the field having char type towards varchar type corresponding of the set operation output type.



### How was the PR tested

Ran successfully locally on `trinodb/trino` the tests from the PR https://github.com/trinodb/trino/pull/19275

```
testing/bin/ptl test run --environment multinode  -- -t io.trino.tests.product.hive.TestHiveViews
```