### PR TITLE
add missing org.codehaus.commons.compiler.properties file to fix Hive view translation 

### DIFF
--- a/src/main/resources/com.linkedin.coral.calcite.$internal.org.codehaus.commons.compiler.properties
+++ b/src/main/resources/com.linkedin.coral.calcite.$internal.org.codehaus.commons.compiler.properties
@@ -1,0 +1,1 @@
+compilerFactory=com.linkedin.coral.calcite.$internal.org.codehaus.janino.CompilerFactory


### PR DESCRIPTION
Fixing an issue when translating a Hive view with `EXISTS` using `hive.hive-views.enabled` which results in the following exception. The  issue is introduced by the shaded coral that missed the required `org.codehaus.commons.compiler.properties` file, and this PR adds the corresponding shaded version of the property file by adding the correct prefix(`com.linkedin.coral.calcite.$internal`) to file name and factory class.
![SCR-20240501-muo](https://github.com/trinodb/trino-coral/assets/6486980/58452761-e62f-4f88-a5fe-c6e449f24fa6)

Slack conversation: https://trinodb.slack.com/archives/CP1MUNEUX/p1714606316166899


```
io.trino.spi.TrinoException: Failed to translate Hive view 'hivetest.hiveview': Unable to instantiate java compiler
    at io.trino.plugin.hive.ViewReaderUtil$HiveViewReader.decodeViewData(ViewReaderUtil.java:266)
    at io.trino.plugin.hive.HiveMetadata.lambda$toConnectorViewDefinition$82(HiveMetadata.java:2904)
    at java.base/java.util.Optional.flatMap(Optional.java:289)
    at io.trino.plugin.hive.HiveMetadata.toConnectorViewDefinition(HiveMetadata.java:2888)
    at io.trino.plugin.hive.HiveMetadata.getView(HiveMetadata.java:2882)
    at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata.getView(ClassLoaderSafeConnectorMetadata.java:743)
    at io.trino.tracing.TracingConnectorMetadata.getView(TracingConnectorMetadata.java:878)
    at io.trino.metadata.MetadataManager.getViewInternal(MetadataManager.java:1537)
    at io.trino.metadata.MetadataManager.getView(MetadataManager.java:1475)
    at io.trino.tracing.TracingMetadata.getView(TracingMetadata.java:894)
    at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitTable(StatementAnalyzer.java:2280)
    at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitTable(StatementAnalyzer.java:521)
    at io.trino.sql.tree.Table.accept(Table.java:60)
    at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
    at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:540)
    at io.trino.sql.analyzer.StatementAnalyzer$Visitor.analyzeFrom(StatementAnalyzer.java:4883)
    at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification(StatementAnalyzer.java:3077)
    at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification(StatementAnalyzer.java:521)
    at io.trino.sql.tree.QuerySpecification.accept(QuerySpecification.java:155)
    at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
    at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:540)
    at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:548)
    at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuery(StatementAnalyzer.java:1565)
    at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuery(StatementAnalyzer.java:521)
    at io.trino.sql.tree.Query.accept(Query.java:118)
    at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
    at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:540)
    at io.trino.sql.analyzer.StatementAnalyzer.analyze(StatementAnalyzer.java:500)
    at io.trino.sql.analyzer.StatementAnalyzer.analyze(StatementAnalyzer.java:489)
    at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:97)
    at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:86)
    at io.trino.execution.SqlQueryExecution.analyze(SqlQueryExecution.java:285)
    at io.trino.execution.SqlQueryExecution.<init>(SqlQueryExecution.java:218)
    at io.trino.execution.SqlQueryExecution$SqlQueryExecutionFactory.createQueryExecution(SqlQueryExecution.java:884)
    at io.trino.dispatcher.LocalDispatchQueryFactory.lambda$createDispatchQuery$0(LocalDispatchQueryFactory.java:153)
    at io.trino.$gen.Trino_446____20240501_220202_2.call(Unknown Source)
    at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:131)
    at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:76)
    at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:82)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
    at java.base/java.lang.Thread.run(Thread.java:1570)
Caused by: java.lang.IllegalStateException: Unable to instantiate java compiler
    at org.apache.calcite.rel.metadata.JaninoRelMetadataProvider.compile(JaninoRelMetadataProvider.java:434)
    at org.apache.calcite.rel.metadata.JaninoRelMetadataProvider.load3(JaninoRelMetadataProvider.java:375)
    at org.apache.calcite.rel.metadata.JaninoRelMetadataProvider.lambda$static$0(JaninoRelMetadataProvider.java:109)
    at com.linkedin.coral.calcite.$internal.com.google.common.cache.CacheLoader$FunctionToCacheLoader.load(CacheLoader.java:149)
    at com.linkedin.coral.calcite.$internal.com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3542)
    at com.linkedin.coral.calcite.$internal.com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2323)
    at com.linkedin.coral.calcite.$internal.com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2286)
    at com.linkedin.coral.calcite.$internal.com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2201)
    at com.linkedin.coral.calcite.$internal.com.google.common.cache.LocalCache.get(LocalCache.java:3953)
    at com.linkedin.coral.calcite.$internal.com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3957)
    at com.linkedin.coral.calcite.$internal.com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4875)
    at org.apache.calcite.rel.metadata.JaninoRelMetadataProvider.create(JaninoRelMetadataProvider.java:475)
    at org.apache.calcite.rel.metadata.JaninoRelMetadataProvider.revise(JaninoRelMetadataProvider.java:488)
    at org.apache.calcite.rel.metadata.RelMetadataQuery.revise(RelMetadataQuery.java:203)
    at org.apache.calcite.rel.metadata.RelMetadataQuery.getMinRowCount(RelMetadataQuery.java:276)
    at org.apache.calcite.sql2rel.SqlToRelConverter.substituteSubQuery(SqlToRelConverter.java:1190)
    at org.apache.calcite.sql2rel.SqlToRelConverter.replaceSubQueries(SqlToRelConverter.java:1014)
    at org.apache.calcite.sql2rel.SqlToRelConverter.convertWhere(SqlToRelConverter.java:980)
    at org.apache.calcite.sql2rel.SqlToRelConverter.convertSelectImpl(SqlToRelConverter.java:649)
    at org.apache.calcite.sql2rel.SqlToRelConverter.convertSelect(SqlToRelConverter.java:627)
    at org.apache.calcite.sql2rel.SqlToRelConverter.convertQueryRecursive(SqlToRelConverter.java:3181)
    at org.apache.calcite.sql2rel.SqlToRelConverter.convertFrom(SqlToRelConverter.java:2124)
    at com.linkedin.coral.hive.hive2rel.HiveSqlToRelConverter.convertFrom(HiveSqlToRelConverter.java:86)
    at org.apache.calcite.sql2rel.SqlToRelConverter.convertFrom(SqlToRelConverter.java:2017)
    at com.linkedin.coral.hive.hive2rel.HiveSqlToRelConverter.convertFrom(HiveSqlToRelConverter.java:86)
    at org.apache.calcite.sql2rel.SqlToRelConverter.convertIdentifier(SqlToRelConverter.java:2337)
    at org.apache.calcite.sql2rel.SqlToRelConverter.convertFrom(SqlToRelConverter.java:2051)
    at com.linkedin.coral.hive.hive2rel.HiveSqlToRelConverter.convertFrom(HiveSqlToRelConverter.java:86)
    at org.apache.calcite.sql2rel.SqlToRelConverter.convertSelectImpl(SqlToRelConverter.java:646)
    at org.apache.calcite.sql2rel.SqlToRelConverter.convertSelect(SqlToRelConverter.java:627)
    at org.apache.calcite.sql2rel.SqlToRelConverter.convertQueryRecursive(SqlToRelConverter.java:3181)
    at com.linkedin.coral.hive.hive2rel.HiveSqlToRelConverter.convertQuery(HiveSqlToRelConverter.java:63)
    at org.apache.calcite.sql2rel.SqlToRelConverter.convertWith(SqlToRelConverter.java:4010)
    at org.apache.calcite.sql2rel.SqlToRelConverter.convertQueryRecursive(SqlToRelConverter.java:3195)
    at com.linkedin.coral.hive.hive2rel.HiveSqlToRelConverter.convertQuery(HiveSqlToRelConverter.java:63)
    at com.linkedin.coral.common.ToRelConverter.toRel(ToRelConverter.java:157)
    at com.linkedin.coral.common.ToRelConverter.convertView(ToRelConverter.java:124)
    at io.trino.plugin.hive.ViewReaderUtil$HiveViewReader.decodeViewData(ViewReaderUtil.java:244)
    ... 41 more
Caused by: java.lang.ClassNotFoundException: No implementation of org.codehaus.commons.compiler is on the class path. Typically, you'd have 'janino.jar', or 'commons-compiler-jdk.jar', or both on the classpath.
    at com.linkedin.coral.calcite.$internal.org.codehaus.commons.compiler.CompilerFactoryFactory.getDefaultCompilerFactory(CompilerFactoryFactory.java:65)
    at org.apache.calcite.rel.metadata.JaninoRelMetadataProvider.compile(JaninoRelMetadataProvider.java:432)
    ... 78
```